### PR TITLE
[BUG] Correctly call repeated actions

### DIFF
--- a/Sources/StatefulViewModel/StatefulViewModel.swift
+++ b/Sources/StatefulViewModel/StatefulViewModel.swift
@@ -98,7 +98,7 @@ private extension StatefulViewModel {
     /// A publisher that combines the action subject and state to handle actions.
     var actionHandler: AnyPublisher<(State, Action), Error> {
         actionPublisher
-            .removeDuplicates()
+//            .removeDuplicates()
             .flatMap { [weak self] action -> AnyPublisher<(State, Action), Error> in
                 guard let self = self else {
                     return Fail(error: CustomError.memoryLeak).eraseToAnyPublisher()


### PR DESCRIPTION
## Description
Due to `removeDuplicates()` the same actions called sequentially are not triggered.